### PR TITLE
Support users using a different command character

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -152,7 +152,7 @@ class ChatHandler {
 	}
 
 	parse(userstr, room, message) {
-		if (message[0] === Config.commandSymbol) {
+		if (message[0] === (Config.commandSymbol || '.')) {
 			this.parseCommand(userstr, room, message);
 		} else if (room) {
 			this.analyze(userstr, room, message);

--- a/command-parser.js
+++ b/command-parser.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 
 const fs = require('fs');
 
@@ -152,7 +152,7 @@ class ChatHandler {
 	}
 
 	parse(userstr, room, message) {
-		if (message[0] === '.') {
+		if (message[0] === Config.commandSymbol) {
 			this.parseCommand(userstr, room, message);
 		} else if (room) {
 			this.analyze(userstr, room, message);


### PR DESCRIPTION
Some users might choose to use a different command character; as such, look to Config.commandSymbol instead of '.' when checking to see if a message is a command.