### PR TITLE
Tours: Fix a typo from a previous commit

### DIFF
--- a/plugins/tours.js
+++ b/plugins/tours.js
@@ -113,7 +113,7 @@ class Tour {
 	addUser(username, fc) {
 		if (this.started) return false;
 		if (this.hasId(toId(username))) return false;
-		if (this.fcs.values().includes(fc)) return false;
+		if (Object.values(this.fcs).includes(fc)) return false;
 
 		Connection.send(`${toId(username)}|You have been successfully signed up for the tournament.`);
 


### PR DESCRIPTION
Commit name states it all. You used `this.fcs.values()` (which doesn't exist) rather than `Object.values(this.fcs)`.
  