### PR TITLE
Tokens: Change expiration from 60 mins => 1 minute

### DIFF
--- a/page.js
+++ b/page.js
@@ -146,7 +146,7 @@ class Page {
 			tokenData.room = room;
 			tokenData.user = userid;
 			tokenData[this.token] = permission;
-			options.token = server.createAccessToken(tokenData, 60);
+			options.token = server.createAccessToken(tokenData, 1);
 		}
 
 		let optionString = Object.keys(options).map(opt => `${toId(opt)}=${toId(options[opt])}`).join('&');


### PR DESCRIPTION
A RO leaked their settings token URL in another public room, and people were then changing the bots settings for the hour until it expired. It shouldn't take more than a minute to click the token link once the bot sends it to the user.